### PR TITLE
change PWP::Encoding to PWP::SingleEncoding

### DIFF
--- a/weaver.ini
+++ b/weaver.ini
@@ -1,6 +1,6 @@
 [@CorePrep]
  
-[-Encoding]
+[-SingleEncoding]
 encoding = iso-8859-1
 [Name]
 [Version]


### PR DESCRIPTION
Hi,

`Pod::Weaver` has `SingleEncoding` plugin now (starting from 4.000). This makes `Pod::Weaver::Plugin::Encoding` an extra dependency that could be thrown away.

See [Rik's post](http://rjbs.manxome.org/rubric/entry/2021) and also check out my quest for details/comments:

> http://questhub.io/realm/perl/quest/5277f3cc9f567ad56f0000e7

Cheers,
Sergey
