### PR TITLE
Use `Dist::Zilla::Plugin::Test::ReportPrereqs` instead of `Dist::Zilla::Plugin::ReportVersions::Tiny`

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -22,7 +22,7 @@ encoding = Latin-1
 
 [AutoPrereqs]
 
-[ReportVersions::Tiny]
+[Test::ReportPrereqs]
 
 [MetaResources]
 repository.web    = http://github.com/book/Games-Mastermind


### PR DESCRIPTION
Use `Dist::Zilla::Plugin::Test::ReportPrereqs` instead of `Dist::Zilla::Plugin::ReportVersions::Tiny`.

According to the [documentation](https://metacpan.org/pod/Dist::Zilla::Plugin::ReportVersions::Tiny) for `ReportVersions::Tiny` it is deprecated and a recommended alternative is [Test::ReportPrereqs](https://metacpan.org/pod/Dist::Zilla::Plugin::Test::ReportPrereqs).

(From [pullrequest.club](https://pullrequest.club/))